### PR TITLE
Add roles based on attribute value (instead of role name)

### DIFF
--- a/module/src/main/java/com/github/lucafilipozzi/keycloak/broker/oidc/mappers/RegexRealmAndClientRoleClaimMapper.java
+++ b/module/src/main/java/com/github/lucafilipozzi/keycloak/broker/oidc/mappers/RegexRealmAndClientRoleClaimMapper.java
@@ -74,6 +74,20 @@ public class RegexRealmAndClientRoleClaimMapper extends AbstractClaimMapper {
     realmRolesRegularExpressionConfigProperty.setHelpText("regular expression to apply to the OIDC claim to extract realm roles; must specify one named-capturing groups: role");
     realmRolesRegularExpressionConfigProperty.setType(ProviderConfigProperty.STRING_TYPE);
     configProperties.add(realmRolesRegularExpressionConfigProperty);
+
+    ProviderConfigProperty searchRolesAttributeNameAttributeNameConfigProperty = new ProviderConfigProperty();
+    searchRolesAttributeNameAttributeNameConfigProperty.setName(RegexRealmAndClientRoleMapperUtil.SEARCH_ROLES_ATTRIBUTE_NAME);
+    searchRolesAttributeNameAttributeNameConfigProperty.setLabel("search roles attribute name");
+    searchRolesAttributeNameAttributeNameConfigProperty.setHelpText("only evaluate realm or client roles having an attribute with this name");
+    searchRolesAttributeNameAttributeNameConfigProperty.setType(ProviderConfigProperty.STRING_TYPE);
+    configProperties.add(searchRolesAttributeNameAttributeNameConfigProperty);
+
+    ProviderConfigProperty searchRolesAttributeNameRegularExpressionConfigProperty = new ProviderConfigProperty();
+    searchRolesAttributeNameRegularExpressionConfigProperty.setName(RegexRealmAndClientRoleMapperUtil.SEARCH_ROLES_REGULAR_EXPRESSION);
+    searchRolesAttributeNameRegularExpressionConfigProperty.setLabel("search roles regular expression");
+    searchRolesAttributeNameRegularExpressionConfigProperty.setHelpText("regular expression to apply to the OIDC claim to search for roles having this attribute value; must specify one named-capturing groups: value");
+    searchRolesAttributeNameRegularExpressionConfigProperty.setType(ProviderConfigProperty.STRING_TYPE);
+    configProperties.add(searchRolesAttributeNameRegularExpressionConfigProperty);
   }
 
   @Override

--- a/module/src/main/java/com/github/lucafilipozzi/keycloak/broker/saml/mappers/RegexRealmAndClientRoleAttributeMapper.java
+++ b/module/src/main/java/com/github/lucafilipozzi/keycloak/broker/saml/mappers/RegexRealmAndClientRoleAttributeMapper.java
@@ -74,6 +74,20 @@ public class RegexRealmAndClientRoleAttributeMapper extends AbstractIdentityProv
     realmRolesRegularExpressionConfigProperty.setHelpText("regular expression to apply to the SAML attribute to extract realm roles; must specify one named-capturing group: role");
     realmRolesRegularExpressionConfigProperty.setType(ProviderConfigProperty.STRING_TYPE);
     configProperties.add(realmRolesRegularExpressionConfigProperty);
+
+    ProviderConfigProperty searchRolesAttributeNameAttributeNameConfigProperty = new ProviderConfigProperty();
+    searchRolesAttributeNameAttributeNameConfigProperty.setName(RegexRealmAndClientRoleMapperUtil.SEARCH_ROLES_ATTRIBUTE_NAME);
+    searchRolesAttributeNameAttributeNameConfigProperty.setLabel("search roles attribute name");
+    searchRolesAttributeNameAttributeNameConfigProperty.setHelpText("only evaluate realm or client roles having an attribute with this name");
+    searchRolesAttributeNameAttributeNameConfigProperty.setType(ProviderConfigProperty.STRING_TYPE);
+    configProperties.add(searchRolesAttributeNameAttributeNameConfigProperty);
+
+    ProviderConfigProperty searchRolesAttributeNameRegularExpressionConfigProperty = new ProviderConfigProperty();
+    searchRolesAttributeNameRegularExpressionConfigProperty.setName(RegexRealmAndClientRoleMapperUtil.SEARCH_ROLES_REGULAR_EXPRESSION);
+    searchRolesAttributeNameRegularExpressionConfigProperty.setLabel("search roles regular expression");
+    searchRolesAttributeNameRegularExpressionConfigProperty.setHelpText("regular expression to apply to the SAML claim to search for roles having this attribute value; must specify one named-capturing groups: value");
+    searchRolesAttributeNameRegularExpressionConfigProperty.setType(ProviderConfigProperty.STRING_TYPE);
+    configProperties.add(searchRolesAttributeNameRegularExpressionConfigProperty);
   }
 
   @Override

--- a/module/src/main/java/com/github/lucafilipozzi/keycloak/broker/util/RegexRealmAndClientRoleMapperUtil.java
+++ b/module/src/main/java/com/github/lucafilipozzi/keycloak/broker/util/RegexRealmAndClientRoleMapperUtil.java
@@ -27,6 +27,10 @@ public final class RegexRealmAndClientRoleMapperUtil {
 
   public static final String REALM_ROLES_REGULAR_EXPRESSION = "realm-roles-regular-expression";
 
+  public static final String SEARCH_ROLES_ATTRIBUTE_NAME = "search-roles-attribute-name";
+
+  public static final String SEARCH_ROLES_REGULAR_EXPRESSION = "search-roles-regular-expression";
+
   private static final Logger LOG = Logger.getLogger(RegexRealmAndClientRoleMapperUtil.class);
 
   private RegexRealmAndClientRoleMapperUtil() {
@@ -39,12 +43,20 @@ public final class RegexRealmAndClientRoleMapperUtil {
     // adjust the user's client role assignments
     String clientRolesRegularExpression = mapper.getConfig().getOrDefault(CLIENT_ROLES_REGULAR_EXPRESSION, "");
     String clientRolesAttributeName = mapper.getConfig().getOrDefault(CLIENT_ROLES_ATTRIBUTE_NAME, "");
-    RegexRealmAndClientRoleMapperUtil.adjustUserClientRoleAssignments(realm, user, assertedValues, clientRolesRegularExpression, clientRolesAttributeName);
+    if(clientRolesRegularExpression != "" && clientRolesAttributeName != "")
+        RegexRealmAndClientRoleMapperUtil.adjustUserClientRoleAssignments(realm, user, assertedValues, clientRolesRegularExpression, clientRolesAttributeName);
 
     // adjust the user's realm role assignments
     String realmRolesRegularExpression = mapper.getConfig().getOrDefault(REALM_ROLES_REGULAR_EXPRESSION, "");
     String realmRolesAttributeName = mapper.getConfig().getOrDefault(REALM_ROLES_ATTRIBUTE_NAME, "");
-    RegexRealmAndClientRoleMapperUtil.adjustUserRealmRoleAssignments(realm, user, assertedValues, realmRolesRegularExpression, realmRolesAttributeName);
+    if(realmRolesRegularExpression != "" && realmRolesRegularExpression != "")
+        RegexRealmAndClientRoleMapperUtil.adjustUserRealmRoleAssignments(realm, user, assertedValues, realmRolesRegularExpression, realmRolesAttributeName);
+
+    // adjust the user's attribute-based (search) role assignments
+    String searchRolesRegularExpression = mapper.getConfig().getOrDefault(SEARCH_ROLES_REGULAR_EXPRESSION, "");
+    String searchRolesAttributeName = mapper.getConfig().getOrDefault(SEARCH_ROLES_ATTRIBUTE_NAME, "");
+    if(searchRolesRegularExpression != "" && searchRolesAttributeName != "")
+        RegexRealmAndClientRoleMapperUtil.adjustUserSearchRoleAssignments(realm, user, assertedValues, searchRolesRegularExpression, searchRolesAttributeName);
   }
 
   private static void adjustUserClientRoleAssignments(RealmModel realm, UserModel user, Set<String> assertedValues, String regularExpression, String attributeName) {
@@ -109,5 +121,11 @@ public final class RegexRealmAndClientRoleMapperUtil {
 
     // un-assign the realm roles that the user has but shouldn't
     Sets.difference(haveRoles, wantRoles).forEach(user::deleteRoleMapping);
+  }
+
+  private static void adjustUserSearchRoleAssignments(RealmModel realm, UserModel user, Set<String> assertedValues, String regularExpression, String attributeName) {
+    LOG.trace("adjust user attribute-based role assignments");
+
+    // TODO
   }
 }


### PR DESCRIPTION
### Description

Currently, roles can only be targeted by their name (and the name of their client for client roles), but I have a case on one of the Keycloak I'm working on, where there is a new permissions auditing software, and all users can only be given permissions from there.
All those permissions are coming from an upstream IDP as claims, but we cannot control their names. On the other side, our clients have roles names imposed by different SP.
The only way I found to make it work is by adding a attribute on each role, with the upstream permission name defined here.

I just had to do a little hack, and I'm open to ideas on how to fix it, but 19.0 branch of keycloak have a bug on the UI where you cannot save more than one attribute with the same name, so I split values by commas, to be able to have multiple upstream permissions for a role.
